### PR TITLE
menuに関するcontrollerの生成

### DIFF
--- a/app/assets/javascripts/menus.coffee
+++ b/app/assets/javascripts/menus.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/menus.scss
+++ b/app/assets/stylesheets/menus.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the menus controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/api/menus_controller.rb
+++ b/app/controllers/api/menus_controller.rb
@@ -1,0 +1,10 @@
+class Api::MenusController < ApplicationController
+  def index
+    # /api/menus.json で仮のJSONを返す
+    # TODO: DBから値取得
+    @menus = [
+      { "name": "さらだ", "description": "おいしいさらだ", "price": 1200, "kcalorie": 298 },
+      { "name": "にく", "description": "おいしいにく", "price": 1320, "kcalorie": 430 },
+    ]
+  end
+end

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,0 +1,4 @@
+class MenusController < ApplicationController
+  def index
+  end
+end

--- a/app/helpers/api/menus_helper.rb
+++ b/app/helpers/api/menus_helper.rb
@@ -1,0 +1,2 @@
+module Api::MenusHelper
+end

--- a/app/helpers/menus_helper.rb
+++ b/app/helpers/menus_helper.rb
@@ -1,0 +1,2 @@
+module MenusHelper
+end

--- a/app/views/api/menus/index.json.jbuilder
+++ b/app/views/api/menus/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.data(@menus) { |d| json.extract!(d, :name, :description, :price, :kcalorie) }

--- a/app/views/menus/index.html.erb
+++ b/app/views/menus/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Menus#index</h1>
+<p>Find me in app/views/menus/index.html.erb</p>

--- a/app/views/menus/index.html.erb
+++ b/app/views/menus/index.html.erb
@@ -1,2 +1,2 @@
 <h1>Menus#index</h1>
-<p>Find me in app/views/menus/index.html.erb</p>
+<p>ここにReactコンポーネント</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,10 @@
 Rails.application.routes.draw do
+  namespace :api do
+    get 'menus/index'
+  end
+  namespace :api do
+    resources :menus, only: :index
+  end
+  get 'menus/index'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/test/controllers/api/menus_controller_test.rb
+++ b/test/controllers/api/menus_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class Api::MenusControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get api_menus_index_url
+    assert_response :success
+  end
+
+end

--- a/test/controllers/menus_controller_test.rb
+++ b/test/controllers/menus_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class MenusControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get menus_index_url
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
# 概要
- /api/menus.json で仮のjsonを返すようにする

# 技術的概要
- menuに関するビューのcontroller, APIのcontrollerを生成
- APIのcontrollerにてインスタンス変数に仮のJSONを格納
- 上記に伴うroutingの修正