### PR TITLE
ハンバーガーメニューの作成・フッターのスタイル修正

### DIFF
--- a/app/assets/javascripts/header.js
+++ b/app/assets/javascripts/header.js
@@ -1,0 +1,11 @@
+function openMenu(){
+  $(".navbar").css("display", "block");
+  $(".openMenuBtn").css("display", "none");
+  $(".closeMenuBtn").css("display", "block");
+};
+
+function closeMenu(){
+  $(".navbar").css("display", "none");
+  $(".openMenuBtn").css("display", "block");
+  $(".closeMenuBtn").css("display", "none");
+};

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -19,13 +19,13 @@
  }
 
 html{
-  height: 100%;
+  height: auto;
   min-height: 100%;
-
 }
 
  body{
    margin: 0;
-   height: 100%;
+   height: -webkit-fill-available;
    min-height: 100%;
+   bottom: 0;
  }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -47,3 +47,15 @@ body{
 .closeMenuBtn{
   display: none;
 }
+
+.openMenuBtn-hamburger{
+  display: block;
+  width: 30px;
+  height: 2px;
+  margin: 7px 10px;
+  background-color: #fff;
+  border: 1px solid #fff;
+  &:first-child{
+    margin: 15px 10px 7px;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -40,12 +40,17 @@ body{
 .openMenuBtn, .closeMenuBtn{
   cursor: pointer;
   float: right;
-  color: #fff;
   z-index: 1035;
 }
 
+.openMenuBtn{
+  color: #fff;
+}
+
 .closeMenuBtn{
+  color: #777;
   display: none;
+  margin-right: 10px;
 }
 
 .openMenuBtn-hamburger{

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,9 +23,27 @@ html{
   min-height: 100%;
 }
 
- body{
-   margin: 0;
-   height: -webkit-fill-available;
-   min-height: 100%;
-   bottom: 0;
- }
+body{
+  margin: 0;
+  height: -webkit-fill-available;
+  min-height: 100%;
+  bottom: 0;
+}
+
+@media screen and (max-width: 400px){
+  .navbar{
+    display: none;
+    z-index: 0;
+  }
+}
+
+.openMenuBtn, .closeMenuBtn{
+  cursor: pointer;
+  float: right;
+  color: #fff;
+  z-index: 1035;
+}
+
+.closeMenuBtn{
+  display: none;
+}

--- a/app/assets/stylesheets/categories.scss
+++ b/app/assets/stylesheets/categories.scss
@@ -5,7 +5,9 @@
 @mixin categories-list($cat-list-font-size){
   .categories{
     background: #FF9935;
+    width: 100%;
     height: 100%;
+    min-width: 100%;
     min-height: 100%;
     padding: 0 1em;
     &-list{

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -2,30 +2,35 @@
 @import "bootstrap";
 
 footer {
-  margin-top: 45px;
-  padding-top: 5px;
-  border-top: 1px solid #eaeaea;
-  color: #777;
-}
-
-footer a {
-  color: #555;
-}
-
-footer a:hover {
-  color: #222;
-}
-
-footer small {
-  float: left;
-}
-
-footer ul {
-  float: right;
-  list-style: none;
-}
-
-footer ul li {
-  float: left;
-  margin-left: 15px;
+  padding: 30px 0 35px;
+  color: #FFF;
+  background-color: #FF9935;
+  opacity: 0.7;
+  a {
+    color: #FFF;
+    &:hover {
+      color: #FFF;
+      font-weight: 700;
+    }
+  }
+  small {
+    display: block;
+    text-align: center;
+  }
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 5px 0 0;
+    text-align: center;
+    li {
+      display: inline;
+      &::after{
+        content: " | ";
+        padding: 0 10px;
+      }
+      &:last-child::after{
+        content: ""
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1,6 +1,14 @@
 @import "bootstrap-sprockets";
 @import "bootstrap";
 
+.navbar{ // override bootstrap
+  background-color: rgba(255, 255, 255, 0.8);
+  border: none;
+  .navbar-nav > li > a{
+    color: #777;
+  }
+}
+
 footer {
   padding: 30px 0 35px;
   color: #FFF;

--- a/app/assets/stylesheets/menus.scss
+++ b/app/assets/stylesheets/menus.scss
@@ -5,6 +5,7 @@
   background-color: #FF9935;
   height: 100%;
   min-height: 100%;
+  background-attachment: fixed;
   &__name{
     color: #fff;
     font-weight: 700;
@@ -53,5 +54,12 @@
     &--address{
       margin: 0;
     }
+  }
+  &__back_to_top--from_menu{
+    margin: 15px 0 0;
+    display: block;
+    color: #fff;
+    text-align: center;
+    text-decoration: underline;
   }
 }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,8 @@
-<button class="openMenuBtn" onClick="openMenu();">menu</button>
+<button class="openMenuBtn" onClick="openMenu();">
+  <span class="openMenuBtn-hamburger"></span>
+  <span class="openMenuBtn-hamburger"></span>
+  <span class="openMenuBtn-hamburger"></span>
+</button>
 <header>
   <div class="container navbar navbar-fixed-top navbar-inverse">
     <nav>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,11 +1,12 @@
-<header class="navbar navbar-fixed-top navbar-inverse">
-  <div class="container">
-    <%= link_to "Healtheats", '/', id: "logo" %>
+<button class="openMenuBtn" onClick="openMenu();">menu</button>
+<header>
+  <div class="container navbar navbar-fixed-top navbar-inverse">
     <nav>
       <ul class="nav navbar-nav navbar-right">
-        <li><%= link_to "Home",   '/' %></li>
-        <li><%= link_to "Category",   categories_path %></li>
+        <li><%= link_to "Healtheats", '/', id: "logo" %></li>
+        <li><%= link_to "Tags",   "#" %></li>
         <li><%= link_to "Log in", login_path %></li>
+        <button class="closeMenuBtn" onClick="closeMenu();">close</button>
       </ul>
     </nav>
   </div>

--- a/app/views/menus/show.html.erb
+++ b/app/views/menus/show.html.erb
@@ -15,4 +15,6 @@
     <p class="menu-detail__restaurant--address"><%= @restaurant.address %></p>
     ここに地図？
   </div>
+  <%= link_to "カテゴリ選択へ戻る", root_path, class: "menu-detail__back_to_top--from_menu" %>
 </div>
+

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,4 +11,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w( header.js )


### PR DESCRIPTION
# 概要
スマホで見やすくなった
<img width="337" alt="2018-10-22 3 40 09" src="https://user-images.githubusercontent.com/29456740/47270820-38de8b00-d5ac-11e8-873f-5e27a6550a96.png">
<img width="332" alt="2018-10-22 3 40 15" src="https://user-images.githubusercontent.com/29456740/47270821-38de8b00-d5ac-11e8-9ccc-07509bdb1edc.png">

# 技術的概要
- header naviのリンク修正
  - Healtheats, home, /categoriesへのパスは全て一緒なのでhomeに統一
  - 今後/tagsへのパスが作られるはずなので、/tagsへのリンクのmockを作成
- header.jsをアセットパイプラインで扱うようにする
- スタイルの修正
  - ハンバーガーメニューはアイコンを読むのではなくspanとスタイルで作った